### PR TITLE
Changed Split parameters to handle hostnames containing semi-columns

### DIFF
--- a/ROS_Comm/RemappingHelper.cs
+++ b/ROS_Comm/RemappingHelper.cs
@@ -16,7 +16,7 @@ namespace Ros_CSharp
             {
                 if (args[i].Contains(":="))
                 {
-                    string[] chunks = args[i].Split(new Char[]{':'},2);
+                    string[] chunks = args[i].Split(new Char[]{':'},2); // Handles master URIs with semi-columns such as http://IP
                     chunks[1] = chunks[1].TrimStart('=').Trim();
                     chunks[0] = chunks[0].Trim();
                     remapping.Add(chunks[0], chunks[1]);


### PR DESCRIPTION
A ROS_MASTER_URI such as http://10.13.235.67 passed as parameter remapping like __master:=http://10.13.235.67 would not be chunked correctly which leads the program to crash.
I added a second parameter to the Split function to only consider two chunks in the split operation.
