### PR TITLE
fixes MD5 generation for certain messages

### DIFF
--- a/YAMLParser/MD5.cs
+++ b/YAMLParser/MD5.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using FauxMessages;
 
 #endregion
@@ -109,7 +110,8 @@ namespace YAMLParser
                     Debug.WriteLine("STILL NEEDS ANOTHER PASS: " + irm.Name + " B/C OF " + irm.Stuff[i].Type);
                     return null;
                 }
-                string[] BLADAMN = hashme.Replace(fields[i].Type,sum).Split('\n');
+                Regex findCurrentFieldType = new Regex("\\b" + fields[i].Type + "\\b");
+                string[] BLADAMN = findCurrentFieldType.Replace(hashme, sum).Split('\n');
                 hashme = "";
                 for (int x = 0; x < BLADAMN.Length; x++)
                 {


### PR DESCRIPTION
MD5 was calculated wrong when one of the types in the message was substring of an other type

e.g. message moveit_msgs/RobotState.msg:
```
sensor_msgs/JointState joint_state
sensor_msgs/MultiDOFJointState multi_dof_joint_state
AttachedCollisionObject[]` attached_collision_objects
bool is_diff
```
resulted in this being hashed:
```
3066dcd76a6cfaef579bd0f34173e9fd joint_state
MultiDOF3066dcd76a6cfaef579bd0f34173e9fd multi_dof_joint_state
3ceac60b21e85bbd6c5b0ab9d476b752 attached_collision_objects
bool is_diff
```
