### PR TITLE
correctly handle deserialization on failed service call

### DIFF
--- a/ROS_Comm/ServiceServerLink.cs
+++ b/ROS_Comm/ServiceServerLink.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using Messages;
 using String = Messages.std_msgs.String;
@@ -283,8 +284,11 @@ namespace Ros_CSharp
                         throw new Exception("HAUUU?!");
                     current_call.resp.Serialized = buf;
                 }
-                else
-                    current_call.exception = new String(buf).data;
+                else if (buf.Length > 0)
+                    // call failed with reason
+                    current_call.exception = Encoding.UTF8.GetString(buf);
+                else { } // call failed, but no reason is given
+
             }
 
             callFinished();
@@ -325,7 +329,11 @@ namespace Ros_CSharp
                 info.finished_condition.WaitOne();
             }
 
-            resp.Deserialize(resp.Serialized);
+            if (info.success)
+            {
+                // response is only sent on success => don't try to deserialize on failure.
+                resp.Deserialize(resp.Serialized);
+            }
 
             if (!string.IsNullOrEmpty(info.exception))
             {


### PR DESCRIPTION
On a failed service call (either service returns `false` or throws exception) deserialization fails with exception:

```
System.ArgumentOutOfRangeException was unhandled by user code
  Message=Index and count must refer to a location within the buffer.
StackTrace:
       at System.Text.ASCIIEncoding.GetString(Byte[] bytes, Int32 byteIndex, Int32 byteCount)
       at Messages.std_msgs.String.Deserialize(Byte[] SERIALIZEDSTUFF, Int32& currentIndex)
       at Messages.IRosMessage.Deserialize(Byte[] SERIALIZEDSTUFF)
       at Messages.std_msgs.String..ctor(Byte[] SERIALIZEDSTUFF)
       at Ros_CSharp.IServiceServerLink.onResponse(Connection conn, Byte[] buf, Int32 size, Boolean success) in ROS.NET\ROS_Comm\ServiceServerLink.cs:line 287
       at System.Runtime.Remoting.Messaging.StackBuilderSink._PrivateProcessMessage(IntPtr md, Object[] args, Object server, Object[]& outArgs)
       at System.Runtime.Remoting.Messaging.StackBuilderSink.AsyncProcessMessage(IMessage msg, IMessageSink replySink)
```
(Tested against ROS Indigo)