### PR TITLE
YAMLParser: some small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Release/*.pdb
 msg_gen/msg_gen.exe
 *.Debug.cachefile
 XmlRpc_Wrapper/XmlRpcWin32.instr.pdb
+
+.vs/
+YAMLParser/*.sln

--- a/YAMLParser/GenerationGuts.cs
+++ b/YAMLParser/GenerationGuts.cs
@@ -614,7 +614,7 @@ namespace FauxMessages
                     def[i] = def[i].Replace("  ", " ");
                 def[i] = def[i].Replace(" = ", "=");
             }
-            GUTS = GUTS.Replace("$MYMESSAGEDEFINITION", "@\"" + def.Aggregate("", (current, d) => current + (d + "\n")).Trim('\n') + "\"");
+            GUTS = GUTS.Replace("$MYMESSAGEDEFINITION", "@\"" + def.Aggregate("", (current, d) => current + (d + "\n")).Trim('\n').Replace("\"", "\"\"") + "\"");
             GUTS = GUTS.Replace("$MYHASHEADER", HasHeader.ToString().ToLower());
             GUTS = GUTS.Replace("$MYFIELDS", GeneratedDictHelper.Length > 5 ? "{{" + GeneratedDictHelper + "}}" : "()");
             GUTS = GUTS.Replace("$NULLCONSTBODY", "");
@@ -1179,7 +1179,9 @@ namespace FauxMessages
         {
             string[] pieces = s.Split('/');
             string package = parent.Package;
-            if (pieces.Length == 2)
+            // sometimes, a string can contain the char '/', such as the following line:
+            // string CONTENT_JSON = "application/json"
+            if (pieces.Length == 2 && !s.ToLower().Contains("string"))
             {
                 package = pieces[0];
                 s = pieces[1];

--- a/YAMLParser/GenerationGuts.cs
+++ b/YAMLParser/GenerationGuts.cs
@@ -94,12 +94,12 @@ namespace FauxMessages
         {
             string[] chunks = Name.Split('.');
             for (int i = 0; i < chunks.Length - 1; i++)
-                outdir += "\\" + chunks[i];
+                outdir += Path.DirectorySeparatorChar + chunks[i];
             if (!Directory.Exists(outdir))
                 Directory.CreateDirectory(outdir);
             string contents = ToString();
             if (contents != null)
-                File.WriteAllText(outdir + "\\" + msgfilelocation.basename + ".cs", contents.Replace("FauxMessages", "Messages"));
+                File.WriteAllText(Path.Combine(outdir, msgfilelocation.basename + ".cs"), contents.Replace("FauxMessages", "Messages"));
         }
 
         public override string ToString()
@@ -1090,7 +1090,7 @@ namespace FauxMessages
         {
             string[] chunks = Name.Split('.');
             for (int i = 0; i < chunks.Length - 1; i++)
-                outdir += "\\" + chunks[i];
+                outdir += Path.DirectorySeparatorChar + chunks[i];
             if (!Directory.Exists(outdir))
                 Directory.CreateDirectory(outdir);
             string localcn = classname;
@@ -1100,9 +1100,9 @@ namespace FauxMessages
             if (contents == null)
                 return;
             if (serviceMessageType == ServiceMessageType.Response)
-                File.AppendAllText(outdir + "\\" + localcn + ".cs", contents.Replace("FauxMessages", "Messages"));
+                File.AppendAllText(Path.Combine(outdir, localcn + ".cs"), contents.Replace("FauxMessages", "Messages"));
             else
-                File.WriteAllText(outdir + "\\" + localcn + ".cs", contents.Replace("FauxMessages", "Messages"));
+                File.WriteAllText(Path.Combine(outdir, localcn + ".cs"), contents.Replace("FauxMessages", "Messages"));
         }
     }
 

--- a/YAMLParser/MsgFileLocator.cs
+++ b/YAMLParser/MsgFileLocator.cs
@@ -35,8 +35,8 @@ namespace YAMLParser
             searchroot = root;
             packagedir = getPackagePath(root, path);
             package = getPackageName(path);
-            extension = path.Split('.').Last();
-            basename = path.Replace(extension, "").Split('\\').Last().Trim('.');
+            extension = System.IO.Path.GetExtension(path).Trim('.');
+            basename = System.IO.Path.GetFileNameWithoutExtension(path);
         }
 
         /// <summary>
@@ -47,17 +47,17 @@ namespace YAMLParser
         /// <returns>"package name"</returns>
         private static string getPackageName(string path)
         {
-            string[] chunks = path.Split('\\');
-            string foldername = chunks[chunks.Length - 2];
+            DirectoryInfo innermostPath = Directory.GetParent(path);
+            string foldername = innermostPath.Name;
             if (msg_gen_folder_names.Contains(foldername))
-                foldername = chunks[chunks.Length - 3];
+                foldername = Directory.GetParent(innermostPath.FullName).Name;
             return foldername;
         }
 
         private static string getPackagePath(string basedir, string msgpath)
         {
             string p = getPackageName(msgpath);
-            return basedir + "\\" + p;
+            return System.IO.Path.Combine(basedir, p);
         }
 
         public override bool Equals(object obj)
@@ -73,7 +73,7 @@ namespace YAMLParser
 
         public override string  ToString()
         {
-            return string.Format("{0}\\{1}.{2}", package, basename, extension);
+            return string.Format("{0}" + System.IO.Path.DirectorySeparatorChar + "{1}.{2}", package, basename, extension);
         }
     }
 

--- a/YAMLParser/Program.cs
+++ b/YAMLParser/Program.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using FauxMessages;
+using static FauxMessages.MsgsFile;
 
 #endregion
 
@@ -90,6 +91,11 @@ namespace YAMLParser
             {
                 srvFiles.Add(new SrvsFile(path));
             }
+            if (!StdMsgsProcessed()) // may seem obvious, but needed so that all other messages can resolve...
+            {
+                Console.WriteLine("std_msgs was not found in any search directory. Exiting...");
+                return;
+            }
             if (paths.Count + pathssrv.Count > 0)
             {
                 MakeTempDir();
@@ -109,6 +115,11 @@ namespace YAMLParser
                 Console.WriteLine("Finished. Press enter.");
                 Console.ReadLine();
             }
+        }
+
+        public static bool StdMsgsProcessed()
+        {
+            return MsgsFile.resolver.ContainsKey("std_msgs");
         }
 
         public static void MakeTempDir()

--- a/YAMLParser/Program.cs
+++ b/YAMLParser/Program.cs
@@ -70,8 +70,8 @@ namespace YAMLParser
                 solutiondir = yamlparser_parent;
             }
 
-            outputdir = solutiondir + outputdir;
-            outputdir_secondpass = solutiondir + outputdir_secondpass;
+            outputdir = Path.Combine(solutiondir, outputdir);
+            outputdir_secondpass = Path.Combine(solutiondir, outputdir_secondpass);
             List<MsgFileLocation> paths = new List<MsgFileLocation>();
             List<MsgFileLocation> pathssrv = new List<MsgFileLocation>();
             Console.WriteLine("Generatinc C# classes for ROS Messages...\n");
@@ -172,7 +172,7 @@ namespace YAMLParser
                 foreach (MsgsFile m in files.Except(mresolved))
                 {
                     string md5 = null;
-                    string typename = null;;
+                    string typename = null;
                     md5 = MD5.Sum(m);
                     typename = m.Name;
                     if (md5 != null && !md5.StartsWith("$") && !md5.EndsWith("MYMD5SUM"))
@@ -222,16 +222,16 @@ namespace YAMLParser
             {
                 file.Write(outputdir);
             }
-            File.WriteAllText(outputdir + "\\MessageTypes.cs", ToString().Replace("FauxMessages", "Messages"));
+            File.WriteAllText(Path.Combine(outputdir, "MessageTypes.cs"), ToString().Replace("FauxMessages", "Messages"));
         }
 
         public static void GenerateProject(List<MsgsFile> files, List<SrvsFile> srvfiles)
         {
-            if (!Directory.Exists(outputdir + "\\Properties"))
-                Directory.CreateDirectory(outputdir + "\\Properties");
-            File.WriteAllText(outputdir + "\\SerializationHelper.cs", Templates.SerializationHelper);
-            File.WriteAllText(outputdir + "\\Interfaces.cs", Templates.Interfaces);
-            File.WriteAllText(outputdir + "\\Properties\\AssemblyInfo.cs", Templates.AssemblyInfo);
+            if (!Directory.Exists(Path.Combine(outputdir, "Properties")))
+                Directory.CreateDirectory(Path.Combine(outputdir, "Properties"));
+            File.WriteAllText(Path.Combine(outputdir, "SerializationHelper.cs"), Templates.SerializationHelper);
+            File.WriteAllText(Path.Combine(outputdir, "Interfaces.cs"), Templates.Interfaces);
+            File.WriteAllText(Path.Combine(outputdir, "Properties", "AssemblyInfo.cs"), Templates.AssemblyInfo);
             string[] lines = Templates.MessagesProj.Split('\n');
             string output = "";
             for (int i = 0; i < lines.Length; i++)
@@ -260,8 +260,8 @@ namespace YAMLParser
                     output += "\t<Compile Include=\"MessageTypes.cs\" />\n";
                 }
             }
-            File.WriteAllText(outputdir + "\\" + name + ".csproj", output);
-            File.WriteAllText(outputdir + "\\.gitignore", "*");
+            File.WriteAllText(Path.Combine(outputdir, name + ".csproj"), output);
+            File.WriteAllText(Path.Combine(outputdir, ".gitignore"), "*");
         }
 
         private static string __where_be_at_my_vc____is;
@@ -271,15 +271,15 @@ namespace YAMLParser
             get
             {
                 if (__where_be_at_my_vc____is != null) return __where_be_at_my_vc____is;
-                foreach (string possibledir in new[] {"\\Microsoft.NET\\Framework64\\", "\\Microsoft.NET\\Framework"})
+                foreach (string possibledir in new[] { Path.DirectorySeparatorChar + Path.Combine("Microsoft.NET", "Framework64") + Path.DirectorySeparatorChar, Path.DirectorySeparatorChar + Path.Combine("Microsoft.NET", "Framework") + Path.DirectorySeparatorChar })
                 {
                     foreach (string possibleversion in new[] {"v3.5", "v4.0"})
                     {
-                        if (!Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.System) + "\\.." + possibledir)) continue;
-                        foreach (string dir in Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.System) + "\\.." + possibledir))
+                        if (!Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.System) + Path.DirectorySeparatorChar + ".." + possibledir)) continue;
+                        foreach (string dir in Directory.GetDirectories(Environment.GetFolderPath(Environment.SpecialFolder.System) + Path.DirectorySeparatorChar + ".." + possibledir))
                         {
                             if (!Directory.Exists(dir)) continue;
-                            string[] tmp = dir.Split('\\');
+                            string[] tmp = dir.Split(Path.DirectorySeparatorChar);
                             if (tmp[tmp.Length - 1].Contains(possibleversion))
                             {
                                 __where_be_at_my_vc____is = dir;
@@ -299,14 +299,14 @@ namespace YAMLParser
 
         public static void BuildProject(string spam)
         {
-            string F = VCDir + "\\msbuild.exe";
+            string F = VCDir + Path.DirectorySeparatorChar + "msbuild.exe";
             if (!File.Exists(F))
             {
                 Exception up = new Exception("ALL OVER YOUR FACE\n" + F);
                 throw up;
             }
             Console.WriteLine("\n\n" + spam);
-            string args = "/nologo \"" + outputdir + "\\" + name + ".csproj\" /property:Configuration="+configuration;
+            string args = "/nologo \"" + Path.Combine(outputdir, name + ".csproj") + Path.DirectorySeparatorChar + " /property:Configuration=" + configuration;
             Process proc = new Process();
             proc.StartInfo.RedirectStandardOutput = true;
             proc.StartInfo.RedirectStandardError = true;
@@ -317,10 +317,10 @@ namespace YAMLParser
             proc.Start();
             string output = proc.StandardOutput.ReadToEnd();
             string error = proc.StandardError.ReadToEnd();
-            if (File.Exists(outputdir + "\\bin\\"+configuration+"\\" + name + ".dll"))
+            if (File.Exists(Path.Combine(outputdir, "bin", configuration, name + ".dll")))
             {
-                Console.WriteLine("\n\nGenerated DLL has been copied to:\n\t" + outputdir + "\\" + name + ".dll\n\n");
-                File.Copy(outputdir + "\\bin\\" + configuration + "\\" + name + ".dll", outputdir + "\\" + name + ".dll", true);
+                Console.WriteLine("\n\nGenerated DLL has been copied to:\n\t" + Path.Combine(outputdir, name + ".dll") + "\n\n");
+                File.Copy(Path.Combine(outputdir, "bin", configuration, name + ".dll"), Path.Combine(outputdir, name + ".dll"), true);
                 Thread.Sleep(100);
             }
             else


### PR DESCRIPTION
This consists of 4 commits to YAMLParser:

- "Add .vs/ and YAMLParser sln files to the gitignore"
I used VS Code to open the repo, and I opened YAMLParser with Visual Studio. Updated the gitignore to ignore the config files for these 2 situations.

- "Use System.IO.Path/Directory/DirectoryInfo for file/directory handling"
This commit does not (or rather, should not) change any part of YAMLParser's functionality. It was just to prep the project so that I could run YAMLParser on Mac/Linux using .NET Core CLI. I'm almost done making the necessary conversions, and might make a separate pull request in case that also sounds like a useful addition.

- "Fix GUTS' character escaping for string constants"
Interestingly, I ran into an issue in YAMLParser where the following lines in a .msg file were not being parsed correctly:
> `string CONTENT_JSON = "application/json"`
> `string CONTENT_STREAM = "application/octet-stream"`

This commit (hopefully) fixes any issues with string constants.

- "Ensure that std_msgs was processed before attempting to generate files"
While testing the .NET Core version of YAMLParser that I've been editing, I ran into an elusive problem where `GenerateFiles()` in Program.cs was stuck in an infinite loop while trying to MD5 hash some .msg files. The issue turned out to be in `PrepareToHash()`: within the method, `irm.Stuff[i].Definer` was always null, because the program could not resolve the `SingleType`s of the messages without std_msgs first being processed. There may be a smarter way to fix this issue, but the easiest solution is to just avoid generating any files if std_msgs was not an included directory.